### PR TITLE
Heartbeat Type Bug Fix

### DIFF
--- a/manifest-google.json
+++ b/manifest-google.json
@@ -13,10 +13,10 @@
         "type": "module"
     },
     "icons": {
-        "16": "images/16.png",
-        "32": "images/32.png",
-        "48": "images/48.png",
-        "128": "images/128.png"
+        "16": "icons/16.png",
+        "32": "icons/32.png",
+        "48": "icons/48.png",
+        "128": "icons/128.png"
     },
     "content_scripts": [
         {

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -47,7 +47,7 @@ class WakaCore {
             plugin: getUserAgent(),
             project: this.getProjectName() ?? "<<LAST_PROJECT>>",
             time: this.getCurrentTime(),
-            type: url,
+            type: "domain",
         };
     }
 


### PR DESCRIPTION
Encountered an issue where the extension was able to successfully send data to WakaTime, but the data wasn't showing up on the [dashboard](https://wakatime.com/dashboard). This was fixed by changing the type of the heartbeat to "domain" instead of URL.

I also encountered an issue with an invalid file path in the manifest-google.json, which was also fixed.